### PR TITLE
Feature/snippet insertion mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
                 "ksp.completion.preferSnippetInsertion": {
                     "type": "boolean",
                     "default": true,
-                    "markdownDescription": "Whether to prefer snippet insertion. (**\\*Language server will be restarted when this setting is changed**)"
+                    "description": "Prioritize snippet insertion when possible."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     ],
     "categories": [
         "Programming Languages",
-        "Linters"
+        "Linters",
+        "Snippets"
     ],
     "galleryBanner": {
         "color": "#3A3D40",
@@ -35,6 +36,7 @@
         "dist/**/*.js",
         "language_server/**",
         "syntaxes/**",
+        "snippets/**",
         "resources/**",
         "language-configuration.json",
         "package.json",
@@ -86,7 +88,13 @@
                     "description": "Whether to prefer snippet insertion."
                 }
             }
-        }
+        },
+        "snippets": [
+            {
+                "language": "ksp",
+                "path": "./snippets/ksp.json"
+            }
+        ]
     },
     "engines": {
         "vscode": "^1.108.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
                 "ksp.completion.preferSnippetInsertion": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether to prefer snippet insertion."
+                    "markdownDescription": "Whether to prefer snippet insertion. (**\\*Language server will be restarted when this setting is changed**)"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,16 @@
                 "title": "Obfuscate Code"
             }
         ],
-        "properties": {}
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "ksp.completion.preferSnippetInsertion": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to prefer snippet insertion."
+                }
+            }
+        }
     },
     "engines": {
         "vscode": "^1.108.0"

--- a/snippets/ksp.json
+++ b/snippets/ksp.json
@@ -1,0 +1,133 @@
+{
+    //--------------------------------------------------------------------------
+    // Code folding
+    //--------------------------------------------------------------------------
+    "region": {
+        "prefix": "region",
+        "body": [
+            "{ #region }"
+        ],
+        "description": ""
+    },
+    "endregion": {
+        "prefix": "endregion",
+        "body": [
+            "{ #endregion }"
+        ],
+        "description": ""
+    },
+
+    //--------------------------------------------------------------------------
+    // Variable declarations : Primitive types
+    //--------------------------------------------------------------------------
+    "declare_variable": {
+        "prefix": "declare",
+        "body": [
+            "declare ${1:name}"
+        ],
+        "description": "declare an user-defined variable"
+    },
+    "declare_int_variable": {
+        "prefix": "int",
+        "body": [
+            "declare $${1:name}"
+        ],
+        "description": "declare an user-defined integer variable"
+    },
+    "declare_int_array_variable": {
+        "prefix": "intarray",
+        "body": [
+            "declare %${1:name}"
+        ],
+        "description": "declare an user-defined integer array variable"
+    },
+    "declare_real_variable": {
+        "prefix": "real",
+        "body": [
+            "declare ~${1:name}"
+        ],
+        "description": "declare an user-defined real variable"
+    },
+    "declare_real_array_variable": {
+        "prefix": "realarray",
+        "body": [
+            "declare ?${1:name}"
+        ],
+        "description": "declare an user-defined real array variable"
+    },
+    "declare_string_variable": {
+        "prefix": "string",
+        "body": [
+            "declare @${1:name}"
+        ],
+        "description": "declare an user-defined string variable"
+    },
+    "declare_string_array_variable": {
+        "prefix": "stringarray",
+        "body": [
+            "declare !${1:name}"
+        ],
+        "description": "declare an user-defined string array variable"
+    },
+
+    //--------------------------------------------------------------------------
+    // Variable declarations : With modifiers
+    //--------------------------------------------------------------------------
+    "declare_const_variable": {
+        "prefix": "const",
+        "body": [
+            "declare const ${1:name} := ${2:value}"
+        ],
+        "description": "declare an user-defined constant variable"
+    },
+    "declare_polyphonic_variable": {
+        "prefix": "polyphonic",
+        "body": [
+            "declare polyphonic ${1:name}"
+        ],
+        "description": "declare an user-defined polyphonic variable"
+    },
+
+    //--------------------------------------------------------------------------
+    // Statements
+    //--------------------------------------------------------------------------
+    "statement_if": {
+        "prefix": "if",
+        "body": [
+            "if(${1:condition})",
+            "    ${2:code}",
+            "end if"
+        ],
+        "description": "if statement"
+    },
+    "statement_ifelse": {
+        "prefix": "ifelse",
+        "body": [
+            "if(${1:condition})",
+            "    ${2:code}",
+            "else",
+            "    ${3:code}",
+            "end if"
+        ],
+        "description": "if...else statement"
+    },
+    "statement_select": {
+        "prefix": "select",
+        "body": [
+            "select(${1:variable})",
+            "    case ${2:case}",
+            "        ${3:code}",
+            "end select"
+        ],
+        "description": "if statement"
+    },
+    "statement_while": {
+        "prefix": "while",
+        "body": [
+            "while(${1:condition})",
+            "    ${2:code}",
+            "end while"
+        ],
+        "description": "while statement"
+    }
+}

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -2,17 +2,33 @@ import * as vscode from 'vscode';
 
 export const CONFIG_SECTION_NAME = 'ksp';
 
-export function getProperty<T>(key: string, defaultValue: T): T | undefined {
-    const section: vscode.WorkspaceConfiguration
-        = vscode.workspace.getConfiguration(CONFIG_SECTION_NAME);
+type ConfigItem<T> = {
+    key: string;
+    defaultValue: T;
+};
+
+// #region Configuration keys
+
+/**
+ * Whether to prefer snippet insertion.
+ */
+export const CONFIG_COMPLETION_PREFER_SNIPPET_INSERTION: ConfigItem<boolean> = {
+    key: 'completion.preferSnippetInsertion',
+    defaultValue: true,
+};
+
+// #endregion
+
+export function getConfigValue<T>(item: ConfigItem<T>): T {
+    const section: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(CONFIG_SECTION_NAME);
 
     if (!section) {
-        return defaultValue;
+        return item.defaultValue;
     }
 
-    const inspect = section.inspect<T>(key);
+    const inspect = section.inspect<T>(item.key);
 
-    let result: T = defaultValue;
+    let result: T = item.defaultValue;
 
     if (!inspect) {
         return result;

--- a/src/configurations.ts
+++ b/src/configurations.ts
@@ -19,6 +19,10 @@ export const CONFIG_COMPLETION_PREFER_SNIPPET_INSERTION: ConfigItem<boolean> = {
 
 // #endregion
 
+export function getConfigName(item: ConfigItem<any>): string {
+    return `${CONFIG_SECTION_NAME}.${item.key}`;
+}
+
 export function getConfigValue<T>(item: ConfigItem<T>): T {
     const section: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(CONFIG_SECTION_NAME);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,19 +56,24 @@ function registerExtensionCommands(context: vscode.ExtensionContext, client: Lan
 
 function registerConfigValueSubscriptions(context: vscode.ExtensionContext) {
     const configChangeDisposable = vscode.workspace.onDidChangeConfiguration(async (event) => {
-
+        //----------------------------------------------------------------------
         // Changed prefer snippet insertion configuration
+        //----------------------------------------------------------------------
         const preferSnippetConfigKey = Configuration.getConfigName(Configuration.CONFIG_COMPLETION_PREFER_SNIPPET_INSERTION);
         if (event.affectsConfiguration(preferSnippetConfigKey)) {
-            OutputChannel.appendLine('Configuration changed: ksp.completion.preferSnippetInsertion');
-            if (!client) {
-                return;
-            }
-            await handleLspServerRestart(context);
+            OutputChannel.appendLine(`Configuration changed: ${preferSnippetConfigKey}`);
+            await handlePreferSnippetInsertionConfigChange(context);
         }
     });
 
     context.subscriptions.push(configChangeDisposable);
+}
+
+async function handlePreferSnippetInsertionConfigChange(context: vscode.ExtensionContext) {
+    if (!client) {
+        return;
+    }
+    await handleLspServerRestart(context);
 }
 
 async function handleLspServerRestart(context: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
+import * as Configuration from './configurations';
 import { LanguageClient } from 'vscode-languageclient/node';
-
 import { OutputChannel } from './constants';
+
 import * as LspClient from './lsp-client';
 import * as Command from './command';
 import * as Obfuscator from './obfuscator';
@@ -26,7 +27,9 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
     }
 
+    registerConfigValueSubscriptions(context);
     registerExtensionCommands(context, client);
+
     OutputChannel.appendLine('KSP extension activated');
 }
 
@@ -49,6 +52,23 @@ function registerExtensionCommands(context: vscode.ExtensionContext, client: Lan
     Command.registerCommand('ksp.obfuscate', context, async () => {
         await handleObfuscateCommand(context);
     });
+}
+
+function registerConfigValueSubscriptions(context: vscode.ExtensionContext) {
+    const configChangeDisposable = vscode.workspace.onDidChangeConfiguration(async (event) => {
+
+        // Changed prefer snippet insertion configuration
+        const preferSnippetConfigKey = Configuration.getConfigName(Configuration.CONFIG_COMPLETION_PREFER_SNIPPET_INSERTION);
+        if (event.affectsConfiguration(preferSnippetConfigKey)) {
+            OutputChannel.appendLine('Configuration changed: ksp.completion.preferSnippetInsertion');
+            if (!client) {
+                return;
+            }
+            await handleLspServerRestart(context);
+        }
+    });
+
+    context.subscriptions.push(configChangeDisposable);
 }
 
 async function handleLspServerRestart(context: vscode.ExtensionContext) {

--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 
+import * as config from  './configurations';
 import * as DotnetInstall from './dotnet-install';
 import { OutputChannel } from './constants';
 
@@ -19,8 +20,8 @@ export async function startLspClient(context: vscode.ExtensionContext): Promise<
     OutputChannel.appendLine(`Server assembly path: ${serverAssembly}`);
 
     const serverOptions: ServerOptions = {
-        run: { command: dotnetPath, args: [serverAssembly], transport: TransportKind.stdio, options: { cwd: serverDirectory } },
-        debug: { command: dotnetPath, args: [serverAssembly], transport: TransportKind.stdio, options: { cwd: serverDirectory } }
+        run: { command: dotnetPath, args: [serverAssembly, ...createClientCommandArgs()], transport: TransportKind.stdio, options: { cwd: serverDirectory } },
+        debug: { command: dotnetPath, args: [serverAssembly, ...createClientCommandArgs()], transport: TransportKind.stdio, options: { cwd: serverDirectory } }
     };
 
     const clientOptions: LanguageClientOptions = {
@@ -34,7 +35,7 @@ export async function startLspClient(context: vscode.ExtensionContext): Promise<
 
     const client = new LanguageClient(
         'ksp',
-        'ksp',
+        'KSP Language Server',
         serverOptions,
         clientOptions
     );
@@ -61,11 +62,28 @@ export async function stopLspClient(context: vscode.ExtensionContext, client: La
     try {
         await client.stop();
         client.dispose();
-    } catch { }
+    } catch (error) {
+        OutputChannel.appendLine('Error stopping KSP LSP client:');
+        OutputChannel.appendLine(`${error}`);
+    }
 
     const index = context.subscriptions.findIndex(d => d === client);
     if (index !== -1) {
         context.subscriptions.splice(index, 1);
     }
     OutputChannel.appendLine('KSP Language Server stopped');
+}
+
+
+function createClientCommandArgs(): string[] {
+    const result: string[] = [];
+    const preferSnippetInsertion = config.getConfigValue(config.CONFIG_COMPLETION_PREFER_SNIPPET_INSERTION);
+
+    if (preferSnippetInsertion) {
+        result.push('--prefer-snippet-insertion');
+    }
+
+    OutputChannel.appendLine(`Client command arguments: ${result.join(' ')}`);
+
+    return result;
 }


### PR DESCRIPTION
https://github.com/users/r-koubou/projects/5/views/1?pane=issue&itemId=172376610

- スニペットとして補完入力の挿入を優先する設定項目を作成（デフォルト：true）
- 設定変更時に言語サーバーを再起動
- 言語サーバーで持つまでもないシンプルないくつかのスニペットをVSCode拡張機能側で定義

---

- Added a setting to prioritize inserting completion inputs as snippets (default: true)
- Restart the Language Server when settings are changed
- Defined some simple snippets in the VSCode extension that do not require language server support.